### PR TITLE
refactor(loader): move UDF0 contract from Loader to capability mix-ins

### DIFF
--- a/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/Loader.java
+++ b/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/Loader.java
@@ -19,11 +19,8 @@ package com.atgenomix.seqslab.piper.plugin.api.loader;
 import com.atgenomix.seqslab.piper.plugin.api.DataSource;
 import com.atgenomix.seqslab.piper.plugin.api.Operator;
 import com.atgenomix.seqslab.piper.tags.DeveloperApi;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.api.java.UDF0;
 import org.apache.spark.sql.types.StructType;
 
-import java.util.Iterator;
 
 /**
  * The operator responsible for loading (reading) a dataset into in-memory DataFrame or copying to local host
@@ -48,7 +45,7 @@ import java.util.Iterator;
  * @see SupportsScanPartitions
  */
 @DeveloperApi
-public interface Loader extends Operator, UDF0<Iterator<Row>> {
+public interface Loader extends Operator {
 
     /**
      * Initializes this operator with a specific data source.

--- a/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/SupportsCopyToLocal.java
+++ b/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/SupportsCopyToLocal.java
@@ -18,6 +18,7 @@ package com.atgenomix.seqslab.piper.plugin.api.loader;
 
 import com.atgenomix.seqslab.piper.tags.DeveloperApi;
 import com.atgenomix.seqslab.piper.tags.FeatureBeforeCall;
+import org.apache.spark.sql.api.java.UDF0;
 
 /**
  * A mix-in interface for {@link Loader}. Dataset loaders can implement this interface to support
@@ -28,7 +29,7 @@ import com.atgenomix.seqslab.piper.tags.FeatureBeforeCall;
  */
 @DeveloperApi
 @FeatureBeforeCall
-public interface SupportsCopyToLocal extends Loader {
+public interface SupportsCopyToLocal extends Loader, UDF0<Void> {
 
     /**
      * Sets the local destination path where the datasets will be saved.

--- a/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/SupportsInMemoryLoading.java
+++ b/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/SupportsInMemoryLoading.java
@@ -18,23 +18,18 @@ package com.atgenomix.seqslab.piper.plugin.api.loader;
 
 import com.atgenomix.seqslab.piper.tags.DeveloperApi;
 import com.atgenomix.seqslab.piper.tags.FeatureBeforeCall;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.api.java.UDF0;
-
-import java.util.Iterator;
-
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 
 /**
  * A mix-in interface for {@link Loader}. Dataset loaders can implement this interface to support
- * transformation of partitioned datasets read by SeqsLab.
+ * copying storage files or directories directly to local file system.
+ * Loaders supporting this interface typically localize datasets that do not require
+ * in-memory processing optimization, e.g. reference files.
+ * This feature is invoked before calling operator function.
  */
 @DeveloperApi
 @FeatureBeforeCall
-public interface SupportsScanPartitions extends Loader, UDF0<Iterator<Row>>  {
-
-    /**
-     * Set the partition loaded by SeqsLab for applying Loader's call function.
-     * @param partition Iterator for the partition
-     */
-    void setPartition(Iterator<Row> partition);
+public interface SupportsInMemoryLoading extends Loader, UDF0<Dataset<Row>> {
 }

--- a/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/SupportsReadPartitions.java
+++ b/src/main/java/com/atgenomix/seqslab/piper/plugin/api/loader/SupportsReadPartitions.java
@@ -18,6 +18,10 @@ package com.atgenomix.seqslab.piper.plugin.api.loader;
 
 import com.atgenomix.seqslab.piper.tags.DeveloperApi;
 import com.atgenomix.seqslab.piper.tags.FeatureBeforeCall;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.api.java.UDF0;
+
+import java.util.Iterator;
 
 /**
  * A mix-in interface for {@link Loader}. Dataset loaders can implement this interface to support
@@ -27,7 +31,7 @@ import com.atgenomix.seqslab.piper.tags.FeatureBeforeCall;
  */
 @DeveloperApi
 @FeatureBeforeCall
-public interface SupportsReadPartitions extends Loader {
+public interface SupportsReadPartitions extends Loader, UDF0<Iterator<Row>> {
 
     /**
      * Get the number of partitions in the data source.


### PR DESCRIPTION
- Remove UDF0<Iterator<Row>> from Loader base interface
- Add UDF0<Void> to SupportsCopyToLocal
- Add UDF0<Iterator<Row>> to SupportsReadPartitions and SupportsScanPartitions
- Add new SupportsInMemoryLoading interface with UDF0<Dataset<Row>>